### PR TITLE
Update DataStore mappings

### DIFF
--- a/contracts/DataStore.sol
+++ b/contracts/DataStore.sol
@@ -22,37 +22,37 @@ contract DataStore is Killable {
         count--;
     }
 
-    mapping (uint => mapping (bytes32 => address)) public AddressStorage;
-    mapping (uint => mapping (bytes32 => uint)) public IntStorage;
-    mapping (uint => mapping (bytes32 => string)) public StringStorage;
+    mapping (bytes32 => address) public AddressStorage;
+    mapping (bytes32 => uint) public IntStorage;
+    mapping (bytes32 => string) public StringStorage;
     // An example Member Data Store:
     // {1: {'name': 'John Doe', 'email': 'john.doe@example.com'}}
     // {2: {'name': 'Johnny Appleseed', 'email': 'johnny.appleseed@icloud.com', 'address': '1, Infinite Loop'}}
 
-    function getAddressValue(uint index, bytes32 key) constant returns (address) {
-        return AddressStorage[index][key];
+    function getAddressValue(bytes32 key) constant returns (address) {
+        return AddressStorage[key];
     }
 
-    function setAddressValue(uint index, bytes32 key, address value) {
-        AddressStorage[index][key] = value;
+    function setAddressValue(bytes32 key, address value) {
+        AddressStorage[key] = value;
     }
 
-    function getIntValue(uint index, bytes32 key) constant returns (uint) {
-        return IntStorage[index][key];
+    function getIntValue(bytes32 key) constant returns (uint) {
+        return IntStorage[key];
     }
 
-    function setIntValue(uint index, bytes32 key, uint value) {
-        IntStorage[index][key] = value;
+    function setIntValue(bytes32 key, uint value) {
+        IntStorage[key] = value;
     }
 
-    function getStringValue(uint index, bytes32 key) constant returns (string) {
+    function getStringValue(bytes32 key) constant returns (string) {
         // This function cannot be used by other contracts or libraries due to an EVM restriction
         // on contracts reading variable-sized data from other contracts.
-        return StringStorage[index][key];
+        return StringStorage[key];
     }
 
-    function setStringValue(uint index, bytes32 key, string value) {
-        StringStorage[index][key] = value;
+    function setStringValue(bytes32 key, string value) {
+        StringStorage[key] = value;
     }
 
     mapping(bytes32 => mapping (address => uint)) AddressIndex;

--- a/contracts/MembersLibrary.sol
+++ b/contracts/MembersLibrary.sol
@@ -45,20 +45,20 @@ library MembersLibrary {
         // }
         memberStore.increaseCount();
         uint memberIndex = memberStore.count();
-        memberStore.setIntValue(index, 'dateAdded', now);
-        memberStore.setIntValue(index, 'state', 0);
+        memberStore.setIntValue(sha3('dateAdded', index), now);
+        memberStore.setIntValue(sha3('state', index), 0);
         // mapping subset memberIndex to superset index
-        memberStore.setIntIndex('memberIndex', memberIndex, index);
-        memberStore.setAddressValue(index, 'account', account);
+        memberStore.setIntIndex(sha3('memberIndex'), memberIndex, index);
+        memberStore.setAddressValue(sha3('account', index), account);
         // memberStore.setAddressIndex('account', account, index);
     }
 
     function removeMember(address memberStoreAddress, address account) {
         var memberStore = DataStore(memberStoreAddress);
         // Deactivate member
-        var accountIndex = memberStore.getAddressIndex('account', account);
+        var accountIndex = memberStore.getAddressIndex(sha3('account'), account);
         if (accountIndex != 0) {
-            memberStore.setIntValue(accountIndex, 'state', 1);
+            memberStore.setIntValue(sha3('state', accountIndex), 1);
             memberStore.decreaseCount();
         }
     }
@@ -68,11 +68,11 @@ library MembersLibrary {
         if (index < 1) {
             return;
         }
-        account = memberStore.getAddressValue(index, 'account');
+        account = memberStore.getAddressValue(sha3('account', index));
         if (account == 0x0) {
             return;
         }
-        state = memberStore.getIntValue(index, 'state');
-        dateAdded = memberStore.getIntValue(index, 'dateAdded');
+        state = memberStore.getIntValue(sha3('state', index));
+        dateAdded = memberStore.getIntValue(sha3('dateAdded', index));
     }
 }

--- a/contracts/Organisation.sol
+++ b/contracts/Organisation.sol
@@ -95,7 +95,7 @@ contract Organisation is Ownable {
         string memory member;
         for (uint i = 1; i <= memberStore.memberCount(); i++) {
             // subset memberIndex key is always stored as "member_account"
-            var index = DataStore(memberStore).getIntIndex('memberIndex', i);
+            var index = DataStore(memberStore).getIntIndex(sha3('memberIndex'), i);
             member = getMember(index);
             count++;
             if (memberString.toSlice().equals("".toSlice())) {


### PR DESCRIPTION
Iterability can be achieved using a regular mapping instead of a
mapping of mappings. This is possible due to hashing that can
include the index itself.